### PR TITLE
Fixed Visualize With Netron for TensorFlow 2.0

### DIFF
--- a/monk/tf_keras_1/finetune/level_14_master_main.py
+++ b/monk/tf_keras_1/finetune/level_14_master_main.py
@@ -301,7 +301,7 @@ class prototype_master(prototype_updates):
         
         batch_size=1;
         if(tf.__version__.split(".")[0] == "2"):
-            x = tf.backend.placeholder(tf.float32, shape=(batch_size, h, w, c)) 
+            x = tf.keras.backend.placeholder(dtype=tf.float32, shape=(batch_size, h, w, c)) 
         else:
             x = tf.placeholder(tf.float32, shape=(batch_size, h, w, c))
         y = self.system_dict["local"]["model"](x)


### PR DESCRIPTION
Users can now use keras with the tensorflow 2.0 backend to visualize theitr Neural Network using Netron.